### PR TITLE
Enhance deployment workflows in GitHub Actions

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -1,8 +1,25 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to deploy'
+        required: true
+        type: string
+      environment:
+        description: 'The environment to deploy to'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
   workflow_call:
     inputs:
+      tag:
+        description: 'The tag to deploy'
+        required: true
+        type: string
       environment:
         description: 'The environment to deploy to'
         required: true
@@ -26,23 +43,42 @@ jobs:
 
   push:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
-      - name: Set tag
-        id: tag
-        run: |
-          echo "Setting the tag"
+      - name: Docker tag (ghcr)
+        id: input_tag
+        uses: ./.github/actions/docker-tag
+        with:
+          tag: ${{ inputs.tag }}
+
+      - name: Login Docker
+        uses: ./.github/actions/login-docker
+        with:
+          registry: ${{ steps.input_tag.outputs.registry }}
+          username: ${{ steps.input_tag.outputs.username }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull image
         run: |
-          echo "Pulling the image"
+          docker pull ${{ inputs.tag }}
 
-      - name: Tag image
-        run: |
-          echo "Tagging the image"
+      - name: Setup Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Docker tag (fly)
+        id: output_tag
+        uses: ./.github/actions/docker-tag
+        with:
+          registry: registry.fly.io
+          username: x
+          image: ${{ secrets.APP_NAME }}
+          version: ${{ steps.input_tag.outputs.version }}
 
       - name: Push image
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          echo "Pushing the image"
+          docker push ${{ steps.output_tag.outputs.tag }}
 
   ready:
     needs: push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           echo "Environment: ${{ matrix.environment }}"
 
   deploy_stage:
-    needs: [context, test]
+    needs: [context, build, test]
     if: ${{ needs.context.outputs.push == 'true' }}
     permissions:
       contents: read
@@ -107,9 +107,10 @@ jobs:
     uses: ./.github/workflows/_deploy.yml
     with:
       environment: stage
+      tag: ${{ needs.build.outputs.tag }}
 
   deploy_prod:
-    needs: [context, deploy_stage]
+    needs: [context, build, test]
     if: ${{ needs.context.outputs.push == 'true' }}
     permissions:
       contents: read
@@ -117,3 +118,4 @@ jobs:
     uses: ./.github/workflows/_deploy.yml
     with:
       environment: prod
+      tag: ${{ needs.build.outputs.tag }}


### PR DESCRIPTION
- Added `workflow_dispatch` inputs for `tag` and `environment` to allow manual deployment configuration.
- Updated the `push` job to utilize the new `tag` input and set the environment dynamically.
- Modified `deploy_stage` and `deploy_prod` jobs to depend on the `build` job and use the output tag for deployment.

These changes improve the flexibility and clarity of the deployment process.