### PR TITLE
Add checkout step in deployment workflow (#14)

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -45,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Docker tag (ghcr)
         id: input_tag
         uses: ./.github/actions/docker-tag


### PR DESCRIPTION
- Added a step to checkout the repository using `actions/checkout@v4` in the deployment job.

This change ensures that the workflow has access to the repository's code during deployment.