### PR TITLE
Remove zx dependency and replace with node built-ins

### DIFF
--- a/docker/scripts/src/index.ts
+++ b/docker/scripts/src/index.ts
@@ -1,4 +1,4 @@
-import { minimist, chalk } from "zx";
+import { parseArgs, chalk } from "./lib.ts";
 
 import {
   Runner,
@@ -46,7 +46,7 @@ export default async function main(
   const logger = new Logger(config);
   const environment = new Environment(config);
   const argv = _argv.slice(2);
-  const args = minimist(argv);
+  const args = parseArgs(argv);
   const runner = new Runner(config, environment, argv, logger);
 
   if (args.help) {

--- a/docker/scripts/src/lib.ts
+++ b/docker/scripts/src/lib.ts
@@ -1,4 +1,7 @@
-import { path, chalk, $, ProcessOutput } from "zx";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { spawn } from "node:child_process";
 import { z } from "zod";
 import { fileURLToPath } from "node:url";
 
@@ -14,6 +17,212 @@ export type Config = z.infer<typeof ConfigSchema>;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const root = path.resolve(__dirname, "..", "..", "..");
+
+// Minimal ANSI color helper (chalk-like)
+type ChalkColor = "black" | "red" | "blue" | "yellow" | "green" | "magenta" | "gray" | "white";
+type ChalkFn = (...args: unknown[]) => string;
+
+function ansi(code: number): ChalkFn {
+  return (...args: unknown[]) => `\x1b[${code}m${args.map(String).join(" ")}\x1b[0m`;
+}
+
+export const chalk: Record<ChalkColor | "bold" | "underline", ChalkFn> & { level?: number } = {
+  black: ansi(30),
+  red: ansi(31),
+  green: ansi(32),
+  yellow: ansi(33),
+  blue: ansi(34),
+  magenta: ansi(35),
+  white: ansi(37),
+  gray: ansi(90),
+  bold: ansi(1),
+  underline: ansi(4),
+  level: 2,
+};
+
+// Minimal argv parser (minimist-like)
+export function parseArgs(argv: string[]): { _: string[]; [key: string]: unknown } {
+  const result: { _: string[]; [key: string]: unknown } = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i] as string;
+    if (token === "--") {
+      // rest are positional
+      result._.push(...argv.slice(i + 1));
+      break;
+    }
+    if (token.startsWith("--")) {
+      const eqIdx = token.indexOf("=");
+      if (token.startsWith("--no-")) {
+        const key = token.slice(5);
+        result[key] = false;
+        continue;
+      }
+      if (eqIdx !== -1) {
+        const key = token.slice(2, eqIdx);
+        const value = token.slice(eqIdx + 1);
+        result[key] = value;
+      } else {
+        const key = token.slice(2);
+        const next = argv[i + 1];
+        if (next && !next.startsWith("-")) {
+          result[key] = next;
+          i++;
+        } else {
+          result[key] = true;
+        }
+      }
+      continue;
+    }
+    if (token.startsWith("-") && token.length > 1) {
+      const flags = token.slice(1).split("");
+      for (const f of flags) result[f] = true;
+      continue;
+    }
+    result._.push(token);
+  }
+  return result;
+}
+
+// Minimal dotenv helpers
+export const dotenv = {
+  load(filePath: string): Record<string, string> {
+    try {
+      const content = fs.readFileSync(filePath, "utf8");
+      const env: Record<string, string> = {};
+      for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith("#")) continue;
+        const eq = line.indexOf("=");
+        if (eq === -1) continue;
+        const key = line.slice(0, eq).trim();
+        let value = line.slice(eq + 1).trim();
+        if (value.startsWith('"') && value.endsWith('"')) {
+          value = value.slice(1, -1);
+        } else if (value.startsWith("'") && value.endsWith("'")) {
+          value = value.slice(1, -1);
+        }
+        env[key] = value;
+      }
+      return env;
+    } catch {
+      return {};
+    }
+  },
+  stringify(env: Record<string, unknown>): string {
+    return Object.entries(env)
+      .map(([k, v]) => `${k}="${v ?? ""}"`)
+      .join("\n");
+  },
+};
+
+export function tmpfile(suffix = "", contents?: string): string {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  const normalized = suffix && !suffix.startsWith(".") && !suffix.startsWith("-") ? `-${suffix}` : suffix;
+  const filePath = path.join(os.tmpdir(), `nopo-${unique}${normalized}`);
+  if (contents !== undefined) {
+    fs.writeFileSync(filePath, contents, "utf8");
+  } else {
+    fs.writeFileSync(filePath, "", "utf8");
+  }
+  return filePath;
+}
+
+export type ExecResult = { stdout: string; stderr: string; exitCode: number };
+
+export class ProcessOutput extends Error {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  constructor(message: string, result: ExecResult) {
+    super(message);
+    this.name = "ProcessOutput";
+    this.stdout = result.stdout;
+    this.stderr = result.stderr;
+    this.exitCode = result.exitCode;
+  }
+}
+
+export type ProcessPromise = Promise<ExecResult> & {
+  nothrow(): Promise<ExecResult>;
+  text(): Promise<string>;
+};
+
+interface ExecOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  verbose?: boolean;
+}
+
+function buildCommand(pieces: TemplateStringsArray, values: unknown[]): string {
+  let out = "";
+  for (let i = 0; i < pieces.length; i++) {
+    out += pieces[i];
+    if (i < values.length) {
+      const value = values[i];
+      if (Array.isArray(value)) {
+        out += value.join(" ");
+      } else {
+        out += String(value ?? "");
+      }
+    }
+  }
+  return out.trim();
+}
+
+export function createExec(options: ExecOptions = {}) {
+  const { cwd, env, verbose = true } = options;
+  const execTag = (pieces: TemplateStringsArray, ...values: unknown[]): ProcessPromise => {
+    const command = buildCommand(pieces, values);
+    if (verbose) {
+      // eslint-disable-next-line no-console
+      console.log(chalk.gray(command));
+    }
+    const child = spawn(command, {
+      cwd,
+      env,
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const base = new Promise<ExecResult>((resolve, reject) => {
+      child.on("error", (err) => {
+        const result: ExecResult = { stdout, stderr: String(err), exitCode: 1 };
+        reject(new ProcessOutput(`Command failed: ${command}`, result));
+      });
+      child.on("close", (code) => {
+        const exitCode = typeof code === "number" ? code : 0;
+        const result: ExecResult = { stdout, stderr, exitCode };
+        if (exitCode === 0) resolve(result);
+        else reject(new ProcessOutput(`Command failed: ${command}`, result));
+      });
+    }) as ProcessPromise;
+
+    base.nothrow = async () => {
+      try {
+        return await base;
+      } catch (err) {
+        if (err instanceof ProcessOutput) {
+          return { stdout: err.stdout, stderr: err.stderr, exitCode: err.exitCode };
+        }
+        return { stdout, stderr: String(err), exitCode: 1 };
+      }
+    };
+    base.text = async () => {
+      const res = await base;
+      return res.stdout.trim();
+    };
+    return base;
+  };
+  return execTag;
+}
 
 interface CreateConfigOptions {
   envFile?: string | undefined;
@@ -56,7 +265,6 @@ export class Logger {
   config: Config;
 
   constructor(config: Config) {
-    chalk.level = 2;
     this.config = config;
   }
 
@@ -98,14 +306,11 @@ export class Script {
   }
 
   get exec() {
-    const shell = $({
+    return createExec({
       cwd: this.runner.config.root,
-      stdio: "pipe",
       verbose: true,
-      env: this.env,
+      env: this.env as NodeJS.ProcessEnv,
     });
-
-    return shell;
   }
 
   log(...message: unknown[]): void {
@@ -177,7 +382,7 @@ export class Runner {
         if (error instanceof ProcessOutput) {
           this.logger.log(chalk.red(error.stdout));
           this.logger.log(chalk.red(error.stderr));
-          this.logger.log(error.stack);
+          this.logger.log(error.stack ?? "");
           process.exit(error.exitCode);
         }
         throw error;

--- a/docker/scripts/src/parse-env.ts
+++ b/docker/scripts/src/parse-env.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { fs, dotenv } from "zx";
+import fs from "node:fs";
+import { dotenv } from "./lib.ts";
 import net from "node:net";
 
 import { DockerTag } from "./docker-tag.ts";

--- a/docker/scripts/src/scripts/build.ts
+++ b/docker/scripts/src/scripts/build.ts
@@ -1,4 +1,4 @@
-import { $, ProcessPromise } from "zx";
+import { createExec, ProcessPromise } from "../lib.ts";
 import { Script, type ScriptDependency } from "../lib.ts";
 import EnvScript from "./env.ts";
 
@@ -22,7 +22,7 @@ export default class BuildScript extends Script {
 
     if (customBuilder) return customBuilder;
 
-    const p = await $`docker buildx inspect ${builder}`.nothrow();
+    const p = await createExec({ cwd: this.runner.config.root, env: this.env })`docker buildx inspect ${builder}`.nothrow();
     if (p.exitCode !== 0) {
       this.log(`Builder '${builder}' not found, creating it...`);
       await this

--- a/docker/scripts/src/scripts/index.ts
+++ b/docker/scripts/src/scripts/index.ts
@@ -1,4 +1,4 @@
-import { minimist } from "zx";
+import { parseArgs } from "../lib.ts";
 import compose from "docker-compose";
 
 import EnvScript from "./env.ts";
@@ -59,7 +59,7 @@ export default class IndexScript extends Script {
     const {
       _: [script, service],
       workspace,
-    } = minimist(runner.argv);
+    } = parseArgs(runner.argv) as { _: (string | undefined)[]; workspace?: string };
 
     return {
       script,


### PR DESCRIPTION
Replaces `zx` dependency with Node.js built-in modules and custom utilities to remove the external dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a0f84ca-13aa-4de1-9cbe-b58eeb336194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a0f84ca-13aa-4de1-9cbe-b58eeb336194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

